### PR TITLE
Bump up commons-compress from 1.20 to 1.21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   // these dependencies have to be explicitly added by the user
   "com.spotify" % "docker-client" % "8.14.3" % Provided,
   "org.vafer" % "jdeb" % "1.7" % Provided artifacts Artifact("jdeb", "jar", "jar"),
-  "org.apache.commons" % "commons-compress" % "1.20",
+  "org.apache.commons" % "commons-compress" % "1.21",
   // for jdkpackager
   "org.apache.ant" % "ant" % "1.10.9",
   // workaround for the command line size limit


### PR DESCRIPTION
There is security vulnerability on commons-compress 1.20 ( CVE-2021-35515 ) 
Need to updated to 1.21